### PR TITLE
Fix power supply logic

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -27,7 +27,7 @@
 // This defines the number of extruders
 #define EXTRUDERS 1
 
-#define POWER_SUPPLY 1 //ATX
+#define POWER_SUPPLY 2 //ATX (with inverted logic)
 
 // Define this to have the electronics keep the power supply off on startup. If you don't know what this is leave it.
 // #define PS_DEFAULT_OFF


### PR DESCRIPTION
While POWER_SUPPLY 2 means the X-Box 360's supply, the EMC02 employs the same
logic, so it would be clearer to just mark it as such.
