### PR TITLE
Disable thermistors for PnP

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -71,10 +71,17 @@
 // 147 is Pt100 with 4k7 pullup
 // 110 is Pt100 with 1k pullup (non standard)
 
+#ifdef FPD_3DPRINTING
 #define TEMP_SENSOR_0 5
 #define TEMP_SENSOR_1 0
 #define TEMP_SENSOR_2 0
 #define TEMP_SENSOR_BED 50
+#else
+#define TEMP_SENSOR_0 0
+#define TEMP_SENSOR_1 0
+#define TEMP_SENSOR_2 0
+#define TEMP_SENSOR_BED 0
+#endif
 
 // This makes temp sensor 1 a redundant sensor for sensor 0. If the temperatures difference between these sensors is to high the print will be aborted.
 //#define TEMP_SENSOR_1_AS_REDUNDANT


### PR DESCRIPTION
Since we don't need the thermistors for PnP, disable them altogether to avoid MINTEMP/MAXTEMP errors
